### PR TITLE
Get GeoJSON overlay working for tile generation with an online source

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ From an online source:
 $ node src/cli.js --style "no" --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 13 --remotesource "bing" --apikey YOUR_API_KEY_HERE
 ```
 
+Online source with GeoJSON overlay:
+
+```bash
+$ node src/cli.js --style "no" --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 13 --remotesource "bing" --apikey YOUR_API_KEY_HERE --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}'
+```
+
 ## Inspect the mbtile outputs
 
 Three easy ways to examine and inspect the mbtiles:

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,42 +1,69 @@
 #!/usr/bin/env node
 
-import fs from 'fs';
-import path from 'path';
-import { program } from"commander";
-import packageJson from '../package.json' assert { type: 'json' };
+import fs from "fs";
+import path from "path";
+import { program } from "commander";
+import packageJson from "../package.json" assert { type: "json" };
 
-import { initiateRendering } from './initiate.js';
+import { initiateRendering } from "./initiate.js";
 
-const parseListToFloat = (text) => text.split(',').map(Number)
+const parseListToFloat = (text) => text.split(",").map(Number);
 
 program
   .version(packageJson.version)
   .name("mbgl-tile-render")
-    .description("Render styled Maplibre GL map tiles")
-  .requiredOption("-s ,--style <type>", "Are you providing your own map style? If not, one will be generated using your sources. (required, 'yes' or 'no')", function(value) {
-    const validSources = ['yes', 'no'];
-    value = value.toLowerCase();
-    if (!validSources.includes(value)) {
-      throw new Error('Invalid answer. It can only be yes or no.');
-    }
-    return value;
-  })    
+  .description("Render styled Maplibre GL map tiles")
+  .requiredOption(
+    "-s ,--style <type>",
+    "Are you providing your own map style? If not, one will be generated using your sources. (required, 'yes' or 'no')",
+    function (value) {
+      const validSources = ["yes", "no"];
+      value = value.toLowerCase();
+      if (!validSources.includes(value)) {
+        throw new Error("Invalid answer. It can only be yes or no.");
+      }
+      return value;
+    },
+  )
   .option("-l, --stylelocation <type>", "Location of your provided map style")
-  .option("-i, --stylesources <type>", "Directory where any local source files specified in your provided style are located")
-  .option("-O, --onlinesource <type>", "Online source type. Options: bing", function(value) {
-    const validSources = ['bing'];
-    value = value.toLowerCase();
-    if (!validSources.includes(value)) {
-      throw new Error('Invalid online source. It can only be bing.');
-    }
-    return value;
-  })
+  .option(
+    "-i, --stylesources <type>",
+    "Directory where any local source files specified in your provided style are located",
+  )
+  .option(
+    "-O, --onlinesource <type>",
+    "Online source type. Options: bing",
+    function (value) {
+      const validSources = ["bing"];
+      value = value.toLowerCase();
+      if (!validSources.includes(value)) {
+        throw new Error("Invalid online source. It can only be bing.");
+      }
+      return value;
+    },
+  )
   .option("-k, --apikey <type>", "API key for your online source (optional)")
-  .option("-a, --overlay <type>", "Feature layer to overlay on top of the online source (must be a GeoJSON object)")
-  .requiredOption("-b, --bounds <type>", "Bounding box in WSEN format, comma separated (required)", parseListToFloat)
-  .option("-z, --minzoom <number>", "Minimum zoom level (default 0)", parseInt, 0)
-  .requiredOption("-Z, --maxzoom <number>", "Maximum zoom level (required)", parseInt)
-  .option("-o, --output <type>", "Output name (default 'output')", "output")
+  .option(
+    "-a, --overlay <type>",
+    "Feature layer to overlay on top of the online source (must be a GeoJSON object)",
+  )
+  .requiredOption(
+    "-b, --bounds <type>",
+    "Bounding box in WSEN format, comma separated (required)",
+    parseListToFloat,
+  )
+  .option(
+    "-z, --minzoom <number>",
+    "Minimum zoom level (default 0)",
+    parseInt,
+    0,
+  )
+  .requiredOption(
+    "-Z, --maxzoom <number>",
+    "Maximum zoom level (required)",
+    parseInt,
+  )
+  .option("-o, --output <type>", "Output name (default 'output')", "output");
 
 program.parse(process.argv);
 
@@ -53,72 +80,88 @@ const minZoom = options.minzoom;
 const maxZoom = options.maxzoom;
 const output = options.output;
 
-if (styleProvided === 'yes' && (!styleLocation || !sourceDir)) {
-    raiseError('You must provide a style location and a source directory if you are providing your own style')
+if (styleProvided === "yes" && (!styleLocation || !sourceDir)) {
+  raiseError(
+    "You must provide a style location and a source directory if you are providing your own style",
+  );
 }
 
-if (styleProvided === 'no' && !onlineSource) {
-    raiseError('You must provide an online source if you are not providing your own style')
+if (styleProvided === "no" && !onlineSource) {
+  raiseError(
+    "You must provide an online source if you are not providing your own style",
+  );
 }
 
 if (minZoom !== null && (minZoom < 0 || minZoom > 22)) {
-    raiseError(`minZoom level is outside supported range (0-22): ${minZoom}`)
+  raiseError(`minZoom level is outside supported range (0-22): ${minZoom}`);
 }
 
 if (maxZoom !== null && (maxZoom < 0 || maxZoom > 22)) {
-    raiseError(`maxZoom level is outside supported range (0-22): ${maxZoom}`)
+  raiseError(`maxZoom level is outside supported range (0-22): ${maxZoom}`);
 }
 
 if (bounds !== null) {
-    if (bounds.length !== 4) {
-        raiseError(
-            `Bounds must be west,south,east,north.  Invalid value found: ${[
-                ...bounds,
-            ]}`
-        )
-    }
+  if (bounds.length !== 4) {
+    raiseError(
+      `Bounds must be west,south,east,north.  Invalid value found: ${[
+        ...bounds,
+      ]}`,
+    );
+  }
 
-    bounds.forEach((b) => {
-        if (!Number.isFinite(b)) {
-            raiseError(
-                `Bounds must be valid floating point values.  Invalid value found: ${[
-                    ...bounds,
-                ]}`
-            )
-        }
-        return null
-    })
+  bounds.forEach((b) => {
+    if (!Number.isFinite(b)) {
+      raiseError(
+        `Bounds must be valid floating point values.  Invalid value found: ${[
+          ...bounds,
+        ]}`,
+      );
+    }
+    return null;
+  });
 
-    const [west, south, east, north] = bounds
-    if (west === east) {
-        raiseError('Bounds west and east coordinate are the same value')
-    }
-    if (south === north) {
-        raiseError('Bounds south and north coordinate are the same value')
-    }
+  const [west, south, east, north] = bounds;
+  if (west === east) {
+    raiseError("Bounds west and east coordinate are the same value");
+  }
+  if (south === north) {
+    raiseError("Bounds south and north coordinate are the same value");
+  }
 }
 
-let style = null
-let styleDir = null
+let style = null;
+let styleDir = null;
 
-if (styleProvided === 'yes') {
-    const stylePath = path.resolve(process.cwd(), styleLocation)
-    styleDir = path.dirname(stylePath)
-    style = JSON.parse(fs.readFileSync(stylePath, 'utf-8'))
+if (styleProvided === "yes") {
+  const stylePath = path.resolve(process.cwd(), styleLocation);
+  styleDir = path.dirname(stylePath);
+  style = JSON.parse(fs.readFileSync(stylePath, "utf-8"));
 }
 
-console.log('\n\n-------- Creating Maplibre GL map tiles --------')
+console.log("\n\n-------- Creating Maplibre GL map tiles --------");
 
-console.log('style provided: %j', styleProvided)
-if (styleLocation) console.log('style location: %j', styleLocation)
-if (sourceDir) console.log('local source path: %j', sourceDir)
-if (onlineSource) console.log('online source: %j', onlineSource)
-if (onlineSourceAPIKey) console.log('api key: %j', onlineSourceAPIKey)
-if (overlaySource) console.log('overlay source: %j', overlaySource)
-console.log('bounds: %j', bounds)
-console.log('minZoom: %j', minZoom)
-console.log('maxZoom: %j', maxZoom)
-console.log('output: %j', output)
-console.log('------------------------------------------------')
+console.log("style provided: %j", styleProvided);
+if (styleLocation) console.log("style location: %j", styleLocation);
+if (sourceDir) console.log("local source path: %j", sourceDir);
+if (onlineSource) console.log("online source: %j", onlineSource);
+if (onlineSourceAPIKey) console.log("api key: %j", onlineSourceAPIKey);
+if (overlaySource) console.log("overlay source: %j", overlaySource);
+console.log("bounds: %j", bounds);
+console.log("minZoom: %j", minZoom);
+console.log("maxZoom: %j", maxZoom);
+console.log("output: %j", output);
+console.log("------------------------------------------------");
 
-initiateRendering(styleProvided === 'yes', style, styleDir, sourceDir, onlineSource, onlineSourceAPIKey, overlaySource, bounds, minZoom, maxZoom, output)
+initiateRendering(
+  styleProvided === "yes",
+  style,
+  styleDir,
+  sourceDir,
+  onlineSource,
+  onlineSourceAPIKey,
+  overlaySource,
+  bounds,
+  minZoom,
+  maxZoom,
+  output,
+);

--- a/src/generate_resources.js
+++ b/src/generate_resources.js
@@ -1,19 +1,22 @@
-import fs from 'fs';
-import path from 'path';
-import axios from 'axios';
+import fs from "fs";
+import path from "path";
+import axios from "axios";
 import sharp from "sharp";
 import MBTiles from "@mapbox/mbtiles";
 
-import { convertCoordinatesToTiles, calculateTileRangeForBounds } from './tile_calculations.js';
+import {
+  convertCoordinatesToTiles,
+  calculateTileRangeForBounds,
+} from "./tile_calculations.js";
 import { renderTile } from "./render_map.js";
 
 // Download XYZ tile
 const downloadXyzTile = async (xyzUrl, filename, onlineSourceAPIKey) => {
   if (fs.existsSync(filename)) return false;
 
-  const config = { responseType: 'arraybuffer' };
+  const config = { responseType: "arraybuffer" };
   if (onlineSourceAPIKey) {
-    config.headers = { 'Authorization': `Bearer ${onlineSourceAPIKey}` };
+    config.headers = { Authorization: `Bearer ${onlineSourceAPIKey}` };
   }
 
   try {
@@ -22,7 +25,9 @@ const downloadXyzTile = async (xyzUrl, filename, onlineSourceAPIKey) => {
       fs.writeFileSync(filename, response.data);
       return true; // Return true if download was successful
     } else {
-      console.log(`Failed to download: ${xyzUrl} (Status code: ${response.status})`);
+      console.log(
+        `Failed to download: ${xyzUrl} (Status code: ${response.status})`,
+      );
       return false;
     }
   } catch (error) {
@@ -32,35 +37,51 @@ const downloadXyzTile = async (xyzUrl, filename, onlineSourceAPIKey) => {
 };
 
 // Download satellite imagery tiles from Bing Maps
-const downloadNaturalEarthTile = async (bounds, onlineSourceAPIKey, maxZoom, tempDir) => {
+const downloadNaturalEarthTile = async (
+  bounds,
+  onlineSourceAPIKey,
+  maxZoom,
+  tempDir,
+) => {
   if (!bounds || bounds.length < 4) {
-    console.error('Invalid bounds provided');
+    console.error("Invalid bounds provided");
     return;
   }
 
-  const rasterImageryUrl = "http://ecn.t3.tiles.virtualearth.net/tiles/a{q}.jpeg?g=1";
+  const rasterImageryUrl =
+    "http://ecn.t3.tiles.virtualearth.net/tiles/a{q}.jpeg?g=1";
   const rasterImageryAttribution = "© Microsoft (Bing Maps)";
-  
-  const xyzOutputDir = tempDir + 'tiles/';
+
+  const xyzOutputDir = tempDir + "sources/";
   if (!fs.existsSync(xyzOutputDir)) {
     fs.mkdirSync(xyzOutputDir, { recursive: true });
   }
 
-  console.log('Downloading satellite imagery raster XYZ tiles from Bing VirtualEarth...');
+  console.log(
+    "Downloading satellite imagery raster XYZ tiles from Bing VirtualEarth...",
+  );
 
   // Iterate over zoom levels and tiles
   // Much of the below code is adapted from Microsoft's Bing Maps Tile System documentation:
   // https://learn.microsoft.com/en-us/bingmaps/articles/bing-maps-tile-system
   for (let zoom = 1; zoom <= maxZoom; zoom++) {
-    let { x: minX, y: maxY } = convertCoordinatesToTiles(bounds[0], bounds[1], zoom);
-    let { x: maxX, y: minY } = convertCoordinatesToTiles(bounds[2], bounds[3], zoom);
+    let { x: minX, y: maxY } = convertCoordinatesToTiles(
+      bounds[0],
+      bounds[1],
+      zoom,
+    );
+    let { x: maxX, y: minY } = convertCoordinatesToTiles(
+      bounds[2],
+      bounds[3],
+      zoom,
+    );
 
     let tileCount = 0;
 
     for (let col = minX; col <= maxX; col++) {
       for (let row = minY; row <= maxY; row++) {
         // Calculate quadkey
-        let quadkey = '';
+        let quadkey = "";
         for (let i = zoom; i > 0; i--) {
           let digit = 0;
           const mask = 1 << (i - 1);
@@ -69,17 +90,26 @@ const downloadNaturalEarthTile = async (bounds, onlineSourceAPIKey, maxZoom, tem
           quadkey += digit.toString();
         }
 
-        const xyzUrl = rasterImageryUrl.replace('{q}', quadkey);
-        const filename = path.join(xyzOutputDir, `${zoom}`, `${col}`, `${row}.jpg`);
+        const xyzUrl = rasterImageryUrl.replace("{q}", quadkey);
+        const filename = path.join(
+          xyzOutputDir,
+          `${zoom}`,
+          `${col}`,
+          `${row}.jpg`,
+        );
         if (!fs.existsSync(path.dirname(filename))) {
           fs.mkdirSync(path.dirname(filename), { recursive: true });
         }
         // Ideally, this would be done using Promise.all() to download multiple tiles at once,
         // But then we run into rate limiting issues with the Bing Maps API
         // https://learn.microsoft.com/en-us/bingmaps/getting-started/bing-maps-api-best-practices
-        const downloadSuccess = await downloadXyzTile(xyzUrl, filename, onlineSourceAPIKey);
+        const downloadSuccess = await downloadXyzTile(
+          xyzUrl,
+          filename,
+          onlineSourceAPIKey,
+        );
         if (downloadSuccess) tileCount++;
-        }
+      }
     }
     console.log(`Zoom level ${zoom} downloaded with ${tileCount} tiles`);
   }
@@ -87,24 +117,36 @@ const downloadNaturalEarthTile = async (bounds, onlineSourceAPIKey, maxZoom, tem
   // Save metadata.json file with proper attribution according to the Bing terms of use
   const metadata = {
     name: "Bing",
-    description: 'Satellite imagery from Bing maps',
-    version: '1.0.0',
+    description: "Satellite imagery from Bing maps",
+    version: "1.0.0",
     attribution: rasterImageryAttribution,
-    format: 'jpg',
-    type: 'overlay'
+    format: "jpg",
+    type: "overlay",
   };
 
-  const metadataFilePath = path.join(xyzOutputDir, 'metadata.json');
+  const metadataFilePath = path.join(xyzOutputDir, "metadata.json");
   fs.writeFileSync(metadataFilePath, JSON.stringify(metadata, null, 4));
 };
 
 // Handler for downloading remote tiles from different sources
-export const downloadRemoteTiles = (onlineSource, onlineSourceAPIKey, bounds, minZoom, maxZoom, tempDir) => {
+export const downloadRemoteTiles = (
+  onlineSource,
+  onlineSourceAPIKey,
+  bounds,
+  minZoom,
+  maxZoom,
+  tempDir,
+) => {
   return new Promise(async (resolve, reject) => {
     try {
       switch (onlineSource) {
         case "bing":
-          await downloadNaturalEarthTile(bounds, onlineSourceAPIKey, maxZoom, tempDir);
+          await downloadNaturalEarthTile(
+            bounds,
+            onlineSourceAPIKey,
+            maxZoom,
+            tempDir,
+          );
           resolve();
           break;
         default:
@@ -119,29 +161,29 @@ export const downloadRemoteTiles = (onlineSource, onlineSourceAPIKey, bounds, mi
 // Generate a Mapbox GL style JSON object from a remote source and an additional source.
 export const generateStyle = (onlineSource, overlaySource) => {
   const style = {
-    "version": 8,
-    "sources": {
+    version: 8,
+    sources: {
       [`${onlineSource}`]: {
-        "type": "raster",
-        "scheme": "xyz",
-        "tilejson": "2.2.0",
-        "tiles": [`tiles/{z}/{x}/{y}.jpg`],
-        "tileSize": 256,
-      }
+        type: "raster",
+        scheme: "xyz",
+        tilejson: "2.2.0",
+        tiles: [`sources/{z}/{x}/{y}.jpg`],
+        tileSize: 256,
+      },
     },
-    "layers": [
+    layers: [
       {
-        "id": "background",
-        "type": "background",
-        "paint": {
+        id: "background",
+        type: "background",
+        paint: {
           "background-color": "#f9f9f9",
         },
       },
       {
-        "id": `${onlineSource}`,
-        "type": "raster",
-        "source": `${onlineSource}`,
-        "paint": {},
+        id: `${onlineSource}`,
+        type: "raster",
+        source: `${onlineSource}`,
+        paint: {},
       },
     ],
   };
@@ -149,27 +191,27 @@ export const generateStyle = (onlineSource, overlaySource) => {
   // transparent red fill and red outline.
   if (overlaySource) {
     style.sources["overlay"] = {
-      "type": "geojson",
-      "data": `overlay.geojson`,
+      type: "geojson",
+      data: `overlay.geojson`,
     };
     style.layers.push({
-      "id": "polygon-layer",
-      "type": "fill",
-      "source": "overlay",
+      id: "polygon-layer",
+      type: "fill",
+      source: "overlay",
       "source-layer": "output",
-      "filter": ["==", "$type", "Polygon"],
-      "paint": {
+      filter: ["==", "$type", "Polygon"],
+      paint: {
         "fill-color": "#FF0000",
         "fill-opacity": 0.5,
       },
     });
     style.layers.push({
-      "id": "line-layer",
-      "type": "line",
-      "source": "overlay",
+      id: "line-layer",
+      type: "line",
+      source: "overlay",
       "source-layer": "output",
-      "filter": ["==", "$type", "LineString"],
-      "paint": {
+      filter: ["==", "$type", "LineString"],
+      paint: {
         "line-color": "#FF0000",
         "line-width": 2,
       },
@@ -212,7 +254,16 @@ export const generateJPG = async (buffer, width, height, ratio) => {
 };
 
 // Generate MBTiles file from a given style, bounds, and zoom range
-export const generateMBTiles = async (style, styleDir, sourceDir, bounds, minZoom, maxZoom, tempDir, output) => {
+export const generateMBTiles = async (
+  style,
+  styleDir,
+  sourceDir,
+  bounds,
+  minZoom,
+  maxZoom,
+  tempDir,
+  output,
+) => {
   const outputPath = `outputs/${output}.mbtiles`;
 
   // Create a new MBTiles file
@@ -233,14 +284,20 @@ export const generateMBTiles = async (style, styleDir, sourceDir, bounds, minZoo
       if (err) {
         throw err;
       } else {
-        let metadata = { name: output, format: "jpg", minzoom: minZoom, maxzoom: maxZoom, type: "overlay" };
+        let metadata = {
+          name: output,
+          format: "jpg",
+          minzoom: minZoom,
+          maxzoom: maxZoom,
+          type: "overlay",
+        };
 
         // Check if metadata.json exists in the sourceDir
-        const metadataFile = path.join(sourceDir, 'metadata.json');
+        const metadataFile = path.join(sourceDir, "metadata.json");
         if (fs.existsSync(metadataFile)) {
           try {
             // Read and parse the metadata.json file
-            const metadataJson = fs.readFileSync(metadataFile, 'utf8');
+            const metadataJson = fs.readFileSync(metadataFile, "utf8");
             const metadataFromFile = JSON.parse(metadataJson);
 
             // Merge the file metadata with the default metadata
@@ -260,14 +317,24 @@ export const generateMBTiles = async (style, styleDir, sourceDir, bounds, minZoo
     for (let zoom = minZoom; zoom <= maxZoom; zoom++) {
       console.log(`Rendering zoom level ${zoom}...`);
       // Calculate tile range for this zoom level based on bounds
-      const { minX, minY, maxX, maxY } = calculateTileRangeForBounds(bounds, zoom);
+      const { minX, minY, maxX, maxY } = calculateTileRangeForBounds(
+        bounds,
+        zoom,
+      );
 
       // Iterate over tiles within the range
       for (let x = minX; x <= maxX; x++) {
         for (let y = minY; y <= maxY; y++) {
           try {
             // Render the tile
-            const tileBuffer = await renderTile(style, styleDir, sourceDir, zoom, x, y);
+            const tileBuffer = await renderTile(
+              style,
+              styleDir,
+              sourceDir,
+              zoom,
+              x,
+              y,
+            );
 
             // Write the tile to the MBTiles file
             mbtiles.putTile(zoom, x, y, tileBuffer, (err) => {
@@ -289,7 +356,7 @@ export const generateMBTiles = async (style, styleDir, sourceDir, bounds, minZoo
       });
     });
   } finally {
-    // Delete the temporary tiles directory and style  
+    // Delete the temporary tiles directory and style
     if (tempDir !== null) {
       await fs.promises.rm(tempDir, { recursive: true });
     }

--- a/src/initiate.js
+++ b/src/initiate.js
@@ -1,77 +1,114 @@
 import fs from "fs";
 import path from "path";
 
-import { downloadRemoteTiles, generateStyle, generateMBTiles } from "./generate_resources.js";
+import {
+  downloadRemoteTiles,
+  generateStyle,
+  generateMBTiles,
+} from "./generate_resources.js";
 
 const MBTILES_REGEXP = /mbtiles:\/\/(\S+?)(?=[/"]+)/gi;
 
-export const initiateRendering = async (styleProvided, styleObject, styleDir, sourceDir, onlineSource, onlineSourceAPIKey, overlaySource, bounds, minZoom, maxZoom, output) => {
-    console.log("Initiating rendering...");
-  
-    let style = styleObject;
-    let tempDir = null;  
-  
-    // If no style is provided, let's generate everything that we need to render tiles.
-    if (!styleProvided) {
-      tempDir = 'outputs/temp/'
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
-      // Download tiles from the online source
-      await downloadRemoteTiles(onlineSource, onlineSourceAPIKey, bounds, minZoom, maxZoom, tempDir);
-      console.log(`Tiles successfully downloaded from ${onlineSource}!`);
-  
-      // Save the overlay GeoJSON to a file, if provided
-      if (overlaySource) {
-        fs.writeFileSync(tempDir + "overlay.geojson", overlaySource);
-      }
-  
-      // Generate and save a stylesheet from the online source and overlay source.
-      if (style === null) {
-        if (!onlineSource) {
-          const msg = "You must provide a online source if you are not providing your own style";
-          throw new Error(msg);
-        } else {
-          style = generateStyle(onlineSource, overlaySource);
-          fs.writeFileSync(tempDir + "style.json", JSON.stringify(style, null, 2));
-          console.log("Style file generated and saved!");
-        }
-      }
-  
-      sourceDir = tempDir + "tiles/";
-      styleDir = path.resolve(process.cwd(), tempDir);
+export const initiateRendering = async (
+  styleProvided,
+  styleObject,
+  styleDir,
+  sourceDir,
+  onlineSource,
+  onlineSourceAPIKey,
+  overlaySource,
+  bounds,
+  minZoom,
+  maxZoom,
+  output,
+) => {
+  console.log("Initiating rendering...");
+
+  let style = styleObject;
+  let tempDir = null;
+
+  // If no style is provided, let's generate everything that we need to render tiles.
+  if (!styleProvided) {
+    tempDir = "outputs/temp/";
+    if (!fs.existsSync(tempDir)) {
+      fs.mkdirSync(tempDir, { recursive: true });
     }
-  
-    const localMbtilesMatches = JSON.stringify(style).match(MBTILES_REGEXP);
-    if (localMbtilesMatches && !sourceDir) {
-      const msg = "Style has local mbtiles file sources, but no sourceDir is set";
-      throw new Error(msg);
+    // Download tiles from the online source
+    await downloadRemoteTiles(
+      onlineSource,
+      onlineSourceAPIKey,
+      bounds,
+      minZoom,
+      maxZoom,
+      tempDir,
+    );
+    console.log(`Tiles successfully downloaded from ${onlineSource}!`);
+
+    // Save the overlay GeoJSON to a file, if provided
+    if (overlaySource) {
+      fs.writeFileSync(tempDir + "sources/overlay.geojson", overlaySource);
     }
-  
-    if (localMbtilesMatches) {
-      localMbtilesMatches.forEach((name) => {
-        const mbtileFilename = path.normalize(
-          path.format({
-            dir: sourceDir,
-            name: name.split("://")[1],
-            ext: ".mbtiles",
-          })
+    console.log(`Overlay GeoJSON saved to file!`);
+
+    // Generate and save a stylesheet from the online source and overlay source.
+    if (style === null) {
+      if (!onlineSource) {
+        const msg =
+          "You must provide a online source if you are not providing your own style";
+        throw new Error(msg);
+      } else {
+        style = generateStyle(onlineSource, overlaySource);
+        fs.writeFileSync(
+          tempDir + "style.json",
+          JSON.stringify(style, null, 2),
         );
-        if (!fs.existsSync(mbtileFilename)) {
-          const msg = `Mbtiles file ${path.format({
-            name,
-            ext: ".mbtiles",
-          })} in style file is not found in: ${path.resolve(sourceDir)}`;
-          throw new Error(msg);
-        }
-      });
+        console.log("Style file generated and saved!");
+      }
     }
-  
-    try {
-      await generateMBTiles(style, styleDir, sourceDir, bounds, minZoom, maxZoom, tempDir, output);
-    } catch (error) {
-      console.error("Error generating MBTiles:", error);
-    }
-  };
-  
+
+    sourceDir = tempDir + "sources/";
+    styleDir = path.resolve(process.cwd(), tempDir);
+  }
+
+  const localMbtilesMatches = JSON.stringify(style).match(MBTILES_REGEXP);
+  if (localMbtilesMatches && !sourceDir) {
+    const msg = "Style has local mbtiles file sources, but no sourceDir is set";
+    throw new Error(msg);
+  }
+
+  if (localMbtilesMatches) {
+    localMbtilesMatches.forEach((name) => {
+      const mbtileFilename = path.normalize(
+        path.format({
+          dir: sourceDir,
+          name: name.split("://")[1],
+          ext: ".mbtiles",
+        }),
+      );
+      if (!fs.existsSync(mbtileFilename)) {
+        const msg = `Mbtiles file ${path.format({
+          name,
+          ext: ".mbtiles",
+        })} in style file is not found in: ${path.resolve(sourceDir)}`;
+        throw new Error(msg);
+      }
+    });
+  }
+
+  try {
+    await generateMBTiles(
+      style,
+      styleDir,
+      sourceDir,
+      bounds,
+      minZoom,
+      maxZoom,
+      tempDir,
+      output,
+    );
+  } catch (error) {
+    console.error("Error generating MBTiles:", error);
+  }
+};
+
 export default initiateRendering;

--- a/src/render_map.js
+++ b/src/render_map.js
@@ -37,7 +37,12 @@ export const renderTile = async (style, styleDir, sourceDir, zoom, x, y) => {
   map.load(style);
 
   // Render the map to a buffer
-  const buffer = await renderMap(map, { zoom: zoom, center: center, height: tileSize, width: tileSize });
+  const buffer = await renderMap(map, {
+    zoom: zoom,
+    center: center,
+    height: tileSize,
+    width: tileSize,
+  });
 
   // Clean up the map instance to free resources
   map.release();

--- a/src/request_resources.js
+++ b/src/request_resources.js
@@ -43,7 +43,7 @@ const getLocalSpriteImage = (styleDir, url, callback) => {
 // Given a URL to a local sprite JSON, get the JSON data.
 const getLocalSpriteJSON = (styleDir, url, callback) => {
   const spriteJsonPath = path.join(styleDir, `${url}`);
-  
+
   // TODO: currently, any styles with sprites defined will
   // fail to render. The callback in this function does
   // correctly return a buffer of the sprite JSON, but
@@ -160,21 +160,21 @@ const getLocalMBTile = (sourceDir, url, callback) => {
 // Fetch a tile from a local XYZ directory.
 const getLocalXYZTile = (sourceDir, url, callback) => {
   /*
-    * @param {String} sourceDir - path containing XYZ tiles.
-    * @param {String} url - url of a data source in style.json file.
-    * @param {function} callback - function to call with (err, {data}).
-    */
+   * @param {String} sourceDir - path containing XYZ tiles.
+   * @param {String} url - url of a data source in style.json file.
+   * @param {function} callback - function to call with (err, {data}).
+   */
   const matches = url.match(XYZ_REGEXP);
   if (!matches) {
-    callback(new Error('Invalid URL format'));
+    callback(new Error("Invalid URL format"));
     return;
   }
-  const [ , z, x, y, ext] = matches;
+  const [, z, x, y, ext] = matches;
   const xyzDir = path.normalize(
     path.format({
       dir: sourceDir,
       name: url.split("://")[1],
-    })
+    }),
   );
 
   const tilePath = path.join(xyzDir, z, x, `${y}.${ext}`);
@@ -198,8 +198,8 @@ const getLocalGeoJSON = (sourceDir, url, callback) => {
   const geojsonFilename = path.normalize(
     path.format({
       dir: sourceDir,
-      name: url
-    })
+      name: url,
+    }),
   );
 
   fs.readFile(geojsonFilename, (err, data) => {
@@ -214,34 +214,36 @@ const getLocalGeoJSON = (sourceDir, url, callback) => {
 
 // requestHandler constructs a request handler for the map to load resources.
 // More about request types (kinds) in MapLibre: https://github.com/maplibre/maplibre-native/blob/main/platform/node/README.md
-export const requestHandler = (styleDir, sourceDir) => ({ url, kind }, callback) => {
+export const requestHandler =
+  (styleDir, sourceDir) =>
+  ({ url, kind }, callback) => {
     try {
       switch (kind) {
         case 2: {
           // source
           if (isMBTilesURL(url)) {
-              getLocalMBTileJSON(sourceDir, url, callback);
+            getLocalMBTileJSON(sourceDir, url, callback);
           } else if (isXYZDirURL(url)) {
-              getLocalXYZTile(sourceDir, url, callback);
+            getLocalXYZTile(sourceDir, url, callback);
           } else if (isGeoJSONURL(url)) {
-              getLocalGeoJSON(sourceDir, url, callback);
+            getLocalGeoJSON(sourceDir, url, callback);
           } else {
-              const msg = `Only local sources are currently supported. Received: ${url}`;
-              throw new Error(msg);
+            const msg = `Only local sources are currently supported. Received: ${url}`;
+            throw new Error(msg);
           }
           break;
         }
         case 3: {
           // tile
           if (isMBTilesURL(url)) {
-              getLocalMBTile(sourceDir, url, callback);
+            getLocalMBTile(sourceDir, url, callback);
           } else if (isXYZDirURL(url)) {
-              getLocalXYZTile(sourceDir, url, callback);
+            getLocalXYZTile(sourceDir, url, callback);
           } else if (isGeoJSONURL(url)) {
-              getLocalGeoJSON(sourceDir, url, callback);
+            getLocalGeoJSON(sourceDir, url, callback);
           } else {
-              const msg = `Only local tiles are currently supported. Received: ${url}`;
-              throw new Error(msg);
+            const msg = `Only local tiles are currently supported. Received: ${url}`;
+            throw new Error(msg);
           }
           break;
         }
@@ -261,8 +263,8 @@ export const requestHandler = (styleDir, sourceDir) => ({ url, kind }, callback)
           break;
         }
         default: {
-            const msg = `Request kind not handled: ${kind}`;
-            throw new Error(msg);
+          const msg = `Request kind not handled: ${kind}`;
+          throw new Error(msg);
         }
       }
     } catch (err) {

--- a/src/tile_calculations.js
+++ b/src/tile_calculations.js
@@ -1,54 +1,64 @@
 // Converts lat/long value to a tile coordinate at a given zoom level, so as to
-// determine X and Y position (column) of a tile in a grid based on geographic longitude 
-// in the Web Mercator projection. 
+// determine X and Y position (column) of a tile in a grid based on geographic longitude
+// in the Web Mercator projection.
 // See: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Lon./lat._to_tile_numbers
 export const convertCoordinatesToTiles = (lon, lat, zoom) => {
-    const n = Math.pow(2, zoom);
-    const x = Math.floor(((lon + 180) / 360) * n);
-    const y = Math.floor((1 - Math.log(Math.tan(lat * Math.PI / 180) + 1 / Math.cos(lat * Math.PI / 180)) / Math.PI) / 2 * n);
-    return { x, y };
-}
+  const n = Math.pow(2, zoom);
+  const x = Math.floor(((lon + 180) / 360) * n);
+  const y = Math.floor(
+    ((1 -
+      Math.log(
+        Math.tan((lat * Math.PI) / 180) + 1 / Math.cos((lat * Math.PI) / 180),
+      ) /
+        Math.PI) /
+      2) *
+      n,
+  );
+  return { x, y };
+};
 
-// Calculates the range of tile coordinates that cover a given geographic bounding box 
+// Calculates the range of tile coordinates that cover a given geographic bounding box
 // at a specific zoom level.
 export const calculateTileRangeForBounds = (bounds, zoom) => {
-    const [minLon, minLat, maxLon, maxLat] = bounds;
+  const [minLon, minLat, maxLon, maxLat] = bounds;
 
-    const { x: minX, y: maxY } = convertCoordinatesToTiles(minLon, minLat, zoom);
-    const { x: maxX, y: minY } = convertCoordinatesToTiles(maxLon, maxLat, zoom);
+  const { x: minX, y: maxY } = convertCoordinatesToTiles(minLon, minLat, zoom);
+  const { x: maxX, y: minY } = convertCoordinatesToTiles(maxLon, maxLat, zoom);
 
-    return { minX, minY, maxX, maxY };
-}
+  return { minX, minY, maxX, maxY };
+};
 
-// Converts tile X and Y coordinates at a given zoom level back to geographic coordinates 
-// (longitude and latitude). 
+// Converts tile X and Y coordinates at a given zoom level back to geographic coordinates
+// (longitude and latitude).
 // See: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Tile_numbers_to_lon..2Flat._2
 export const convertTilesToCoordinates = (x, y, zoom) => {
-    const lon = (x / Math.pow(2, zoom)) * 360 - 180;
-    const latRad = Math.atan(Math.sinh(Math.PI * (1 - 2 * y / Math.pow(2, zoom))));
-    const lat = latRad * 180.0 / Math.PI;
-    return { lon, lat };
-}
+  const lon = (x / Math.pow(2, zoom)) * 360 - 180;
+  const latRad = Math.atan(
+    Math.sinh(Math.PI * (1 - (2 * y) / Math.pow(2, zoom))),
+  );
+  const lat = (latRad * 180.0) / Math.PI;
+  return { lon, lat };
+};
 
 // Calculates mercator-normalized center coordinates of a tile at a given zoom level.
 // More about mercator tile normalization: https://maplibre.org/maplibre-native/docs/book/design/coordinate-system.html
 export const calculateNormalizedCenterCoords = (x, y, zoom) => {
-    // Calculate longitude and latitude from tile x, y, and zoom
-    const nw = convertTilesToCoordinates(x, y, zoom);
-    const se = convertTilesToCoordinates(x + 1, y + 1, zoom);
+  // Calculate longitude and latitude from tile x, y, and zoom
+  const nw = convertTilesToCoordinates(x, y, zoom);
+  const se = convertTilesToCoordinates(x + 1, y + 1, zoom);
 
-    // Normalize latitude to the Mercator projection
-    const mercatorNwY = Math.log(
-        Math.tan(Math.PI / 4 + (nw.lat * Math.PI) / 360)
-    );
-    const mercatorSeY = Math.log(
-        Math.tan(Math.PI / 4 + (se.lat * Math.PI) / 360)
-    );
-    const avgMercatorY = (mercatorNwY + mercatorSeY) / 2;
-    const centerLat = (Math.atan(Math.exp(avgMercatorY)) * 360) / Math.PI - 90;
+  // Normalize latitude to the Mercator projection
+  const mercatorNwY = Math.log(
+    Math.tan(Math.PI / 4 + (nw.lat * Math.PI) / 360),
+  );
+  const mercatorSeY = Math.log(
+    Math.tan(Math.PI / 4 + (se.lat * Math.PI) / 360),
+  );
+  const avgMercatorY = (mercatorNwY + mercatorSeY) / 2;
+  const centerLat = (Math.atan(Math.exp(avgMercatorY)) * 360) / Math.PI - 90;
 
-    // Longitude remains a simple average
-    const centerLon = (nw.lon + se.lon) / 2;
+  // Longitude remains a simple average
+  const centerLon = (nw.lon + se.lon) / 2;
 
-    return [centerLon, centerLat];
-}
+  return [centerLon, centerLat];
+};


### PR DESCRIPTION
## Goal

This is a pretty minor PR (apart from linting noise) to get GeoJSON overlays working with XYZ tiles from an online source. But worth documenting as a pull request because of the significance to our work.

## Screenshots

![image](https://github.com/ConservationMetrics/mbgl-tile-renderer/assets/31662219/9df90c30-6490-40db-8fbf-801a148081b0)

## What I changed

Changed `xyzOutputDir`, and `sourceDir` values, and stylesheet relative path for the overlay, so as to place the XYZ tiles and GeoJSON in the same directory for processing.
