### PR TITLE
Add test run of Docker image with command

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,4 +49,4 @@ jobs:
           short-description: 'Node.js MapGL renderer for styled raster tiles in MBTiles format.'
       - name: Test run of Docker image with command
         run: |
-          docker run --rm communityfirst/mbgl-tile-renderer:${{ steps.meta.outputs.tags[0] }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
+          docker run --rm communityfirst/mbgl-tile-renderer:${{ steps.meta.outputs.tags }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,23 +49,23 @@ jobs:
           short-description: 'Node.js MapGL renderer for styled raster tiles in MBTiles format.'
       - name: Test run of Docker image with self-provided style
         run: |
-          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style self --stylelocation tests/fixtures/alert/style-with-geojson.json --stylesources tests/fixtures/alert/sources --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o /app/outputs/self-${{ steps.meta.outputs.tags }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style self --stylelocation tests/fixtures/alert/style-with-geojson.json --stylesources tests/fixtures/alert/sources --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o /app/outputs/self-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}.mbtiles
       - name: Test run of Docker image with Bing source
         run: |
-          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o /app/outputs/bing-${{ steps.meta.outputs.tags }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o /app/outputs/bing-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}.mbtiles
       - name: Test run of Docker image with Esri source and GeoJSON overlay
         run: |
-          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style esri --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}' -o /app/outputs/esri-${{ steps.meta.outputs.tags }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style esri --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}' -o /app/outputs/esri-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}.mbtiles
       - name: Test run of Docker image with Mapbox source
         run: |
-          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle ${{ secrets.MAPBOX_STYLE }} --apikey ${{ secrets.MAPBOX_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o /app/outputs/mapbox-${{ steps.meta.outputs.tags }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle ${{ secrets.MAPBOX_STYLE }} --apikey ${{ secrets.MAPBOX_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o /app/outputs/mapbox-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}.mbtiles
       - name: Test run of Docker image with Planet source
         run: |
-          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style planet --monthyear 2013-12 --apikey ${{ secrets.PLANET_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 5 -o /app/outputs/planet-${{ steps.meta.outputs.tags }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style planet --monthyear 2013-12 --apikey ${{ secrets.PLANET_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 5 -o /app/outputs/planet-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}.mbtiles
       - name: Upload mbtiles artifacts
         uses: actions/upload-artifact@v2
         with:
           name: mbtiles-${{ steps.meta.outputs.tags }}
-          path: ${{ github.workspace }}/outputs/*.mbtiles
+          path: outputs/*.mbtiles
           if-no-files-found: error # 'warn' or 'ignore' are also available, 'error' will fail the step
           retention-days: ${{ github.event_name == 'release' && 90 || 15 }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,20 +49,23 @@ jobs:
           short-description: 'Node.js MapGL renderer for styled raster tiles in MBTiles format.'
       - name: Test run of Docker image with self-provided style
         run: |
-          docker run --rm -v "$(pwd)/outputs:/app/outputs" ${{ steps.meta.outputs.tags }} --style self --stylelocation tests/fixtures/alert/style-with-geojson.json --stylesources tests/fixtures/alert/sources --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o ./outputs/self-${{ steps.meta.outputs.tags }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style self --stylelocation tests/fixtures/alert/style-with-geojson.json --stylesources tests/fixtures/alert/sources --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o /app/outputs/self-${{ steps.meta.outputs.tags }}.mbtiles
       - name: Test run of Docker image with Bing source
         run: |
-          docker run --rm -v "$(pwd)/outputs:/app/outputs" ${{ steps.meta.outputs.tags }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o ./outputs/bing-${{ steps.meta.outputs.tags }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o /app/outputs/bing-${{ steps.meta.outputs.tags }}.mbtiles
       - name: Test run of Docker image with Esri source and GeoJSON overlay
         run: |
-          docker run --rm -v "$(pwd)/outputs:/app/outputs" ${{ steps.meta.outputs.tags }} --style esri --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}' -o ./outputs/esri-${{ steps.meta.outputs.tags }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style esri --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}' -o /app/outputs/esri-${{ steps.meta.outputs.tags }}.mbtiles
       - name: Test run of Docker image with Mapbox source
         run: |
-          docker run --rm -v "$(pwd)/outputs:/app/outputs" ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle ${{ secrets.MAPBOX_STYLE }} --apikey ${{ secrets.MAPBOX_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o ./outputs/mapbox-${{ steps.meta.outputs.tags }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle ${{ secrets.MAPBOX_STYLE }} --apikey ${{ secrets.MAPBOX_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o /app/outputs/mapbox-${{ steps.meta.outputs.tags }}.mbtiles
       - name: Test run of Docker image with Planet source
         run: |
-          docker run --rm -v "$(pwd)/outputs:/app/outputs" ${{ steps.meta.outputs.tags }} --style planet --monthyear 2013-12 --apikey ${{ secrets.PLANET_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 5 -o ./outputs/planet-${{ steps.meta.outputs.tags }}.mbtiles
-      - uses: actions/upload-artifact@v4
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style planet --monthyear 2013-12 --apikey ${{ secrets.PLANET_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 5 -o /app/outputs/planet-${{ steps.meta.outputs.tags }}.mbtiles
+      - name: Upload mbtiles artifacts
+        uses: actions/upload-artifact@v2
         with:
           name: mbtiles-${{ steps.meta.outputs.tags }}
-          path: outputs/*.mbtiles
+          path: ${{ github.workspace }}/outputs/*.mbtiles
+          if-no-files-found: error # 'warn' or 'ignore' are also available, 'error' will fail the step
+          retention-days: ${{ github.event_name == 'release' && 90 || 15 }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,9 +56,9 @@ jobs:
       - name: Test run of Docker image with Esri source and GeoJSON overlay
         run: |
           docker run --rm ${{ steps.meta.outputs.tags }} --style esri --apikey YOUR_API_KEY_HERE --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}'
-      # - name: Test run of Docker image with Mapbox source
-      #   run: |
-      #     docker run --rm ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle ${{ secrets.MAPBOX_STYLE }} --apikey ${{ secrets.MAPBOX_API_KEY }}  --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
-      # - name: Test run of Docker image with Planet source
-      #   run: |
-      #     docker run --rm ${{ steps.meta.outputs.tags }} --style planet --monthyear 2013-12 --apikey ${{ secrets.PLANET_API_KEY }}  --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 5
+      - name: Test run of Docker image with Mapbox source
+        run: |
+          docker run --rm ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle ${{ secrets.MAPBOX_STYLE }} --apikey ${{ secrets.MAPBOX_API_KEY }}  --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
+      - name: Test run of Docker image with Planet source
+        run: |
+          docker run --rm ${{ steps.meta.outputs.tags }} --style planet --monthyear 2013-12 --apikey ${{ secrets.PLANET_API_KEY }}  --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 5

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
           docker run --rm ${{ steps.meta.outputs.tags }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
       - name: Test run of Docker image with Esri source and GeoJSON overlay
         run: |
-          docker run --rm ${{ steps.meta.outputs.tags }} --style esri --apikey YOUR_API_KEY_HERE --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}'
+          docker run --rm ${{ steps.meta.outputs.tags }} --style esri --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}'
       - name: Test run of Docker image with Mapbox source
         run: |
           docker run --rm ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle ${{ secrets.MAPBOX_STYLE }} --apikey ${{ secrets.MAPBOX_API_KEY }}  --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,3 +47,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: communityfirst/mbgl-tile-renderer
           short-description: 'Node.js MapGL renderer for styled raster tiles in MBTiles format.'
+      - name: Test run of Docker image with command
+        run: |
+          docker run --rm communityfirst/mbgl-tile-renderer:${{ steps.meta.outputs.tags[0] }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,16 +49,20 @@ jobs:
           short-description: 'Node.js MapGL renderer for styled raster tiles in MBTiles format.'
       - name: Test run of Docker image with self-provided style
         run: |
-          docker run --rm ${{ steps.meta.outputs.tags }} --style self --stylelocation tests/fixtures/alert/style-with-geojson.json --stylesources tests/fixtures/alert/sources --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
+          docker run --rm -v "$(pwd)/outputs:/app/outputs" ${{ steps.meta.outputs.tags }} --style self --stylelocation tests/fixtures/alert/style-with-geojson.json --stylesources tests/fixtures/alert/sources --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o ./outputs/self-${{ steps.meta.outputs.tags }}.mbtiles
       - name: Test run of Docker image with Bing source
         run: |
-          docker run --rm ${{ steps.meta.outputs.tags }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
+          docker run --rm -v "$(pwd)/outputs:/app/outputs" ${{ steps.meta.outputs.tags }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o ./outputs/bing-${{ steps.meta.outputs.tags }}.mbtiles
       - name: Test run of Docker image with Esri source and GeoJSON overlay
         run: |
-          docker run --rm ${{ steps.meta.outputs.tags }} --style esri --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}'
+          docker run --rm -v "$(pwd)/outputs:/app/outputs" ${{ steps.meta.outputs.tags }} --style esri --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}' -o ./outputs/esri-${{ steps.meta.outputs.tags }}.mbtiles
       - name: Test run of Docker image with Mapbox source
         run: |
-          docker run --rm ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle ${{ secrets.MAPBOX_STYLE }} --apikey ${{ secrets.MAPBOX_API_KEY }}  --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
+          docker run --rm -v "$(pwd)/outputs:/app/outputs" ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle ${{ secrets.MAPBOX_STYLE }} --apikey ${{ secrets.MAPBOX_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o ./outputs/mapbox-${{ steps.meta.outputs.tags }}.mbtiles
       - name: Test run of Docker image with Planet source
         run: |
-          docker run --rm ${{ steps.meta.outputs.tags }} --style planet --monthyear 2013-12 --apikey ${{ secrets.PLANET_API_KEY }}  --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 5
+          docker run --rm -v "$(pwd)/outputs:/app/outputs" ${{ steps.meta.outputs.tags }} --style planet --monthyear 2013-12 --apikey ${{ secrets.PLANET_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 5 -o ./outputs/planet-${{ steps.meta.outputs.tags }}.mbtiles
+      - uses: actions/upload-artifact@v4
+        with:
+          name: mbtiles-${{ steps.meta.outputs.tags }}
+          path: outputs/*.mbtiles

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,4 +49,4 @@ jobs:
           short-description: 'Node.js MapGL renderer for styled raster tiles in MBTiles format.'
       - name: Test run of Docker image with command
         run: |
-          docker run --rm communityfirst/mbgl-tile-renderer:${{ steps.meta.outputs.tags }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
+          docker run --rm ${{ steps.meta.outputs.tags }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,7 +58,7 @@ jobs:
           docker run --rm ${{ steps.meta.outputs.tags }} --style esri --apikey YOUR_API_KEY_HERE --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}'
       # - name: Test run of Docker image with Mapbox source
       #   run: |
-      #     docker run --rm ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle YOUR_USERNAME/YOUR_MAPBOX_STYLE_ID --apikey YOUR_API_KEY_HERE --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
+      #     docker run --rm ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle ${{ secrets.MAPBOX_STYLE }} --apikey ${{ secrets.MAPBOX_API_KEY }}  --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
       # - name: Test run of Docker image with Planet source
       #   run: |
-      #     docker run --rm ${{ steps.meta.outputs.tags }} --style planet --monthyear 2013-12 --apikey YOUR_API_KEY_HERE --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
+      #     docker run --rm ${{ steps.meta.outputs.tags }} --style planet --monthyear 2013-12 --apikey ${{ secrets.PLANET_API_KEY }}  --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 5

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,23 +49,23 @@ jobs:
           short-description: 'Node.js MapGL renderer for styled raster tiles in MBTiles format.'
       - name: Test run of Docker image with self-provided style
         run: |
-          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style self --stylelocation tests/fixtures/alert/style-with-geojson.json --stylesources tests/fixtures/alert/sources --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o /app/outputs/self-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style self --stylelocation tests/fixtures/alert/style-with-geojson.json --stylesources tests/fixtures/alert/sources --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o self-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
       - name: Test run of Docker image with Bing source
         run: |
-          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o /app/outputs/bing-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o bing-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
       - name: Test run of Docker image with Esri source and GeoJSON overlay
         run: |
-          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style esri --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}' -o /app/outputs/esri-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style esri --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}' -o esri-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
       - name: Test run of Docker image with Mapbox source
         run: |
-          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle ${{ secrets.MAPBOX_STYLE }} --apikey ${{ secrets.MAPBOX_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o /app/outputs/mapbox-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle ${{ secrets.MAPBOX_STYLE }} --apikey ${{ secrets.MAPBOX_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 -o mapbox-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
       - name: Test run of Docker image with Planet source
         run: |
-          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style planet --monthyear 2013-12 --apikey ${{ secrets.PLANET_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 5 -o /app/outputs/planet-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}.mbtiles
+          docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs ${{ steps.meta.outputs.tags }} --style planet --monthyear 2013-12 --apikey ${{ secrets.PLANET_API_KEY }} --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 5 -o planet-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
       - name: Upload mbtiles artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: mbtiles-${{ steps.meta.outputs.tags }}
+          name: mbtiles-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
           path: outputs/*.mbtiles
           if-no-files-found: error # 'warn' or 'ignore' are also available, 'error' will fail the step
           retention-days: ${{ github.event_name == 'release' && 90 || 15 }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,6 +47,18 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: communityfirst/mbgl-tile-renderer
           short-description: 'Node.js MapGL renderer for styled raster tiles in MBTiles format.'
-      - name: Test run of Docker image with command
+      - name: Test run of Docker image with self-provided style
+        run: |
+          docker run --rm ${{ steps.meta.outputs.tags }} --style self --stylelocation tests/fixtures/alert/style-with-geojson.json --stylesources tests/fixtures/alert/sources --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
+      - name: Test run of Docker image with Bing source
         run: |
           docker run --rm ${{ steps.meta.outputs.tags }} --style bing --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
+      - name: Test run of Docker image with Esri source and GeoJSON overlay
+        run: |
+          docker run --rm ${{ steps.meta.outputs.tags }} --style esri --apikey YOUR_API_KEY_HERE --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}'
+      # - name: Test run of Docker image with Mapbox source
+      #   run: |
+      #     docker run --rm ${{ steps.meta.outputs.tags }} --style mapbox --mapboxstyle YOUR_USERNAME/YOUR_MAPBOX_STYLE_ID --apikey YOUR_API_KEY_HERE --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10
+      # - name: Test run of Docker image with Planet source
+      #   run: |
+      #     docker run --rm ${{ steps.meta.outputs.tags }} --style planet --monthyear 2013-12 --apikey YOUR_API_KEY_HERE --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 10

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,6 @@ ENV DISPLAY=:99.0
 RUN start-stop-daemon --start --pidfile ~/xvfb.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset
 COPY ./src/* /app/src/
 COPY entrypoint.sh /app
+COPY ./tests/* /app/tests/
 RUN chmod +x /app/entrypoint.sh
 ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ ENV DISPLAY=:99.0
 RUN start-stop-daemon --start --pidfile ~/xvfb.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset
 COPY ./src/* /app/src/
 COPY entrypoint.sh /app
-COPY ./tests/* /app/tests/
+COPY ./tests/ /app/tests/
 RUN chmod +x /app/entrypoint.sh
 ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mbgl-tile-renderer
 
+[![Publish to DockerHub](https://github.com/ConservationMetrics/mbgl-tile-renderer/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/ConservationMetrics/mbgl-tile-renderer/actions/workflows/docker-publish.yml)
+
 This headless Node.js MapGL renderer generates styled raster tiles in an MBTiles format. It can work with a self-provided stylesheet and tile sources, or an online source with an optional overlay. 
 
 It uses [Maplibre-GL Native](https://www.npmjs.com/package/@maplibre/maplibre-gl-native) to render tiles, [Sharp](https://www.npmjs.com/package/sharp) to save them as an image, and Mapbox's [mbtiles Node package](https://www.npmjs.com/package/@mapbox/mbtiles) to compile them into an mbtiles database.


### PR DESCRIPTION
## Goal
Do some basic testing using the deployed Docker image, for PR as well as releases.
 - [x] Test run of Docker image with self-provided style                        
 - [x] Test run of Docker image with Bing source                                
 - [x] Test run of Docker image with Esri source and GeoJSON overlay            
 - [x] Test run of Docker image with Mapbox and Mapbox Style
 - [x] Test run of Docker image with Planet source

## What I changed
Runs a simple scrapping of tiles up to zoom 10 to check everything is smorking.

## What I'm not doing here
Write tests of every command. Ideally should have a basic test suite in NodeJS as well.
