### PR TITLE
Improved and streamlined validations & error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Common options:
 *  `-o` or `--outputdir`: Output directory (default "outputs/")
 *  `-f` or `--filename`: Name of the output mbtiles file
 
-## Example usage
+## CLI example usage
 
 Using a self-provided style:
 
@@ -94,6 +94,21 @@ Online source (Esri) with GeoJSON overlay:
 
 ```bash
 $ node src/cli.js --style esri --apikey YOUR_API_KEY_HERE --bounds "-54.28772,3.11460,-54.03630,3.35025" -Z 13 --overlay '{"type": "FeatureCollection", "name": "alert", "features": [{"geometry": {"coordinates": [[[-54.25348208981326, 3.140689896338671], [-54.25348208981326, 3.140600064810259], [-54.253841415926914, 3.140600064810259], [-54.25348208981326, 3.140689896338671]]], "geodesic": false, "type": "Polygon"}, "id": "-603946+34961", "properties": {"month_detec": "09", "year_detec": "2023"}, "type": "Feature"}]}'
+```
+
+## Azure Storage Queue example usage
+
+For Azure Storage Queue (and other queue services in the future), mbgl-tile-renderer expects a message with a JSON body, composed of the input options:
+
+```json
+{
+  "style": "bing",
+  "apiKey": "bing-api-key",
+  "bounds": "-54.28772,3.11460,-54.03630,3.35025",
+  "minZoom": 0,
+  "maxZoom": 8,
+  "output": "bing"
+}
 ```
 
 ## Docker

--- a/src/tile_calculations.js
+++ b/src/tile_calculations.js
@@ -1,3 +1,16 @@
+export const validateMinMaxValues = (minX, minY, maxX, maxY) => {
+  if (isNaN(minX) || isNaN(maxX) || isNaN(minY) || isNaN(maxY)) {
+    throw new Error("One or more tile coordinates are NaN");
+  }
+
+  if (minX > maxX) {
+    throw new Error("minX cannot be greater than maxX");
+  }
+  if (minY > maxY) {
+    throw new Error("minY cannot be greater than maxY");
+  }
+};
+
 // Converts lat/long value to a tile coordinate at a given zoom level, so as to
 // determine X and Y position (column) of a tile in a grid based on geographic longitude
 // in the Web Mercator projection.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,130 @@
+export const parseListToFloat = (text) => text.split(",").map(Number);
+
+export const raiseError = (msg) => {
+  console.error("ERROR:", msg);
+  process.exit(1);
+};
+
+// Currently supported list of online styles
+// When adding a new style, make sure to update this list
+const validOnlineStyles = [
+  "bing",
+  "esri",
+  "google",
+  "mapbox",
+  "mapbox-satellite",
+  "planet",
+];
+
+export const validateInputOptions = (
+  style,
+  styleDir,
+  sourceDir,
+  apiKey,
+  mapboxStyle,
+  monthYear,
+  overlay,
+  bounds,
+  minZoom,
+  maxZoom,
+) => {
+  if (!style) {
+    raiseError("You must provide a style");
+  }
+
+  if (!validOnlineStyles.includes(style) && style !== "self") {
+    raiseError(
+      `Invalid style. Supported styles: ${validOnlineStyles.join(", ")}, self`,
+    );
+  }
+
+  if (style === "self" && (!styleDir || !sourceDir)) {
+    raiseError(
+      "If you are providing your own style, you must provide a style location and a source directory",
+    );
+  }
+
+  if (
+    (style === "mapbox" ||
+      style === "mapbox-satellite" ||
+      style === "planet") &&
+    !apiKey
+  ) {
+    raiseError(`You must provide an API key for ${style}`);
+  }
+
+  if (style === "planet" && !monthYear) {
+    raiseError(
+      "If you are using Planet as your online source, you must provide a month and year (YYYY-MM)",
+    );
+  }
+
+  // Ensure monthYear is in the right format
+  if (monthYear) {
+    const monthYearFormat = /^\d{4}-\d{2}$/;
+    if (!monthYearFormat.test(monthYear)) {
+      raiseError("Month and year must be in YYYY-MM format");
+    }
+  }
+
+  if (style === "mapbox" && !mapboxStyle) {
+    raiseError(
+      "If you are using Mapbox as your online source, you must provide a Mapbox style URL",
+    );
+  }
+
+  if (mapboxStyle) {
+    const mapboxStyleFormat = /^[\w-]+\/[\w-]+$/;
+    if (!mapboxStyleFormat.test(mapboxStyle)) {
+      raiseError(
+        "Mapbox style URL must be in a valid format: <yourusername>/<styleid>",
+      );
+    }
+  }
+
+  // Ensure overlay is a JSON object
+  if (overlay) {
+    try {
+      JSON.parse(overlay);
+    } catch (e) {
+      raiseError("Overlay must be a valid JSON object");
+    }
+  }
+
+  if (minZoom !== null && (minZoom < 0 || minZoom > 22)) {
+    raiseError(`minZoom level is outside supported range (0-22): ${minZoom}`);
+  }
+
+  if (maxZoom !== null && (maxZoom < 0 || maxZoom > 22)) {
+    raiseError(`maxZoom level is outside supported range (0-22): ${maxZoom}`);
+  }
+
+  if (bounds !== null) {
+    if (bounds.length !== 4) {
+      raiseError(
+        `Bounds must be west,south,east,north.  Invalid value found: ${[
+          ...bounds,
+        ]}`,
+      );
+    }
+
+    bounds.forEach((b) => {
+      if (!Number.isFinite(b)) {
+        raiseError(
+          `Bounds must be valid floating point values.  Invalid value found: ${[
+            ...bounds,
+          ]}`,
+        );
+      }
+      return null;
+    });
+
+    const [west, south, east, north] = bounds;
+    if (west === east) {
+      raiseError("Bounds west and east coordinate are the same value");
+    }
+    if (south === north) {
+      raiseError("Bounds south and north coordinate are the same value");
+    }
+  }
+};


### PR DESCRIPTION
Closes #19.

## Goal

The goal here is to improve the overall robustness of validations and error handling in mbgl-tile-renderer by applying the same input validations for CLI and Azure Storage Queue, handling several edge cases throughout the flow, and throwing an error instead of console logging whenever a breaking behavior has been encountered. 

## What I changed

* Across the codebase, throw errors when something irredeemable has happened. In the cases where an error is encountered but the flow can still take place, I added documentation as to why in the comments.
* Moved the input validations from `cli.js` into its own function `validateInputOptions` in `utils.js`, and call this function for both CLI and ASQ inputs.
* Created a new function `validateMinMaxValues` to validate minX, MinY, maxX, maxY values before iterating over an XYZ tile range. (I have seen erroneous values being generated as a result of not receiving the bbox as an array but as a string. We are now also ensuring the bbox is an array before initiating anything, but nevertheless thought it would be good to account for this edge case.)
* Moved a couple of repeated functions to `utils.js` to streamline the code.
* For `style: self` cases, first ensure a temp dir exists before starting to write an MBTiles file there. (I think this got broken through a previous commit.)
* Document sample message for ASQ.